### PR TITLE
chore: Add action to check docker lint

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -7,12 +7,22 @@ on:
       - dev
     tags:
       - v*
+  pull_request:
+    branches:
+      - main
+      - dev
 
 env:
   IMAGE_NAME: curlybox
 
 jobs:
-  test:
+  lint:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2 
+      - name: hadolint
+        uses: reviewdog/action-hadolint@v1
+  build:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -22,6 +22,8 @@ jobs:
       - uses: actions/checkout@v2 
       - name: hadolint
         uses: reviewdog/action-hadolint@v1
+        with:
+          filter_mode: nofilter
   build:
     needs: lint
     runs-on: ubuntu-latest

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -23,13 +23,14 @@ jobs:
       - name: hadolint
         uses: reviewdog/action-hadolint@v1
   build:
+    needs: lint
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
       - name: Build
         run: docker build . --file Dockerfile --tag $GITHUB_SHA
   push:
-    needs: test
+    needs: build
     runs-on: ubuntu-latest
     if: github.event_name == 'push'
     permissions:

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,14 +1,12 @@
-FROM alpine as build
-RUN apk update \
-    && apk add ca-certificates
+FROM alpine:3.13.5 as build
+RUN apk add --no-cache ca-certificates=20191127-r5 
 
 ARG CURL_BIN_URL=https://github.com/moparisthebest/static-curl/releases/download/v7.76.1/curl-amd64
 
-RUN wget -O curl ${CURL_BIN_URL} \
+RUN wget -q -O curl ${CURL_BIN_URL} \
     && chmod +x curl \
     && mv curl /bin/curl
 
 FROM busybox:1.33.1
-
 COPY --from=build /etc/ssl/certs /etc/ssl/certs
 COPY --from=build /bin/curl /bin/curl

--- a/Dockerfile
+++ b/Dockerfile
@@ -9,5 +9,6 @@ RUN wget -O curl ${CURL_BIN_URL} \
     && mv curl /bin/curl
 
 FROM busybox:1.33.1
+
 COPY --from=build /etc/ssl/certs /etc/ssl/certs
 COPY --from=build /bin/curl /bin/curl


### PR DESCRIPTION
Fixes #7

- Add reviewdog/hadolint to check lint and report on PR